### PR TITLE
Snap to closest

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,21 @@ A RuneLite plugin that allows you to control the camera direction by simply clic
 
 ## Configuration
 
-This plugin is simple and doesn’t require additional configuration. By default, it controls the camera based on the current facing direction:
+This plugin is simple and has two modes:
 
-How it works:
+#### Cycle Mode (default)
+
 1. If facing North, the camera will rotate to South.
 2. If facing South, it will rotate to East.
 3. If facing East, it will rotate to West.
 4. If facing any other direction, it will rotate North.
 
 The process repeats when clicking the compass orb.
+
+#### Snap to Closest
+
+When clicking the compass, the camera will snap to the closest cardinal direction.
+Useful for spinning the camera manually, then aligning to the grid.
 
 ## Issues and Feedback
 

--- a/src/main/java/com/compassCameraControl/CompassCameraControlConfig.java
+++ b/src/main/java/com/compassCameraControl/CompassCameraControlConfig.java
@@ -1,0 +1,22 @@
+package com.compassCameraControl;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup("compasscameracontrol")
+public interface CompassCameraControlConfig extends Config
+{
+
+	@ConfigItem(
+		keyName = "controlMode",
+		name = "Mode",
+		description = "Cycle: North -> South -> East -> West<br/>" +
+			"Snap to Closest: Snaps the camera to the nearest cardinal direction"
+	)
+	default ControlMode controlMode()
+	{
+		return ControlMode.CYCLE;
+	}
+
+}

--- a/src/main/java/com/compassCameraControl/CompassCameraControlPlugin.java
+++ b/src/main/java/com/compassCameraControl/CompassCameraControlPlugin.java
@@ -1,13 +1,16 @@
 package com.compassCameraControl;
 
+import com.google.inject.Provides;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
+import net.runelite.api.MenuAction;
+import net.runelite.api.events.MenuOptionClicked;
+import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
-import net.runelite.api.MenuAction;
-import net.runelite.api.events.MenuOptionClicked;
 
 @Slf4j
 @PluginDescriptor(
@@ -18,26 +21,89 @@ public class CompassCameraControlPlugin extends Plugin
 	@Inject
 	private Client client;
 
+	@Inject
+	private CompassCameraControlConfig config;
+
 	private static final int NORTH_YAW = 0;
 	private static final int SOUTH_YAW = 1024;
 	private static final int EAST_YAW = 512;
 	private static final int WEST_YAW = 1536;
 
 	@Subscribe
-	public void onMenuOptionClicked(MenuOptionClicked event) {
-		if (event.getMenuAction() == MenuAction.CC_OP && event.getMenuOption().equals("Look North")) {
-			if (client.getCameraYaw() == NORTH_YAW) {
-				client.setCameraYawTarget(SOUTH_YAW);
-				event.consume();
+	public void onMenuOptionClicked(MenuOptionClicked event)
+	{
+		if (event.getMenuAction() == MenuAction.CC_OP && event.getMenuOption().equals("Look North"))
+		{
+			switch (config.controlMode())
+			{
+				case SNAP_TO_CLOSEST:
+					alignYaw();
+					break;
+
+				case CYCLE:
+				default:
+					cycleYaw();
+					break;
 			}
-			if (client.getCameraYaw() == SOUTH_YAW) {
-				client.setCameraYawTarget(EAST_YAW);
-				event.consume();
-			}
-			if (client.getCameraYaw() == EAST_YAW) {
-				client.setCameraYawTarget(WEST_YAW);
-				event.consume();
-			}
+			event.consume();
 		}
+	}
+
+	@Provides
+	@Singleton
+	CompassCameraControlConfig provideConfig(ConfigManager configManager)
+	{
+		return configManager.getConfig(CompassCameraControlConfig.class);
+	}
+
+	private void cycleYaw()
+	{
+		switch (client.getCameraYaw())
+		{
+			case NORTH_YAW:
+				client.setCameraYawTarget(SOUTH_YAW);
+				break;
+
+			case SOUTH_YAW:
+				client.setCameraYawTarget(EAST_YAW);
+				break;
+
+			case EAST_YAW:
+				client.setCameraYawTarget(WEST_YAW);
+				break;
+
+			default:
+				client.setCameraYawTarget(NORTH_YAW);
+		}
+	}
+
+	private void alignYaw()
+	{
+		int dNorth = Math.abs(client.getCameraYawTarget() - NORTH_YAW);
+		int closestYaw = NORTH_YAW;
+		int closestYawDistance = dNorth;
+
+		int dSouth = Math.abs(client.getCameraYawTarget() - SOUTH_YAW);
+		if (dSouth < closestYawDistance)
+		{
+			closestYaw = SOUTH_YAW;
+			closestYawDistance = dSouth;
+		}
+
+		int dEast = Math.abs(client.getCameraYawTarget() - EAST_YAW);
+		if (dEast < closestYawDistance)
+		{
+			closestYaw = EAST_YAW;
+			closestYawDistance = dEast;
+		}
+
+		int dWest = Math.abs(client.getCameraYawTarget() - WEST_YAW);
+		if (dWest < closestYawDistance)
+		{
+			closestYaw = WEST_YAW;
+			closestYawDistance = dWest;
+		}
+
+		client.setCameraYawTarget(closestYaw);
 	}
 }

--- a/src/main/java/com/compassCameraControl/ControlMode.java
+++ b/src/main/java/com/compassCameraControl/ControlMode.java
@@ -1,0 +1,21 @@
+package com.compassCameraControl;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum ControlMode
+{
+
+	CYCLE("Cycle"),
+	SNAP_TO_CLOSEST("Snap to Closest"),
+	;
+
+	private final String name;
+
+	@Override
+	public String toString()
+	{
+		// for config option dropdown to show proper capitalization
+		return name;
+	}
+}


### PR DESCRIPTION
Hi! I just saw your plugin on first review, and I have had this idea for a while to just snap the camera to the closest cardinal direction. I thought it might be a good fit to place them into the same plugin as different modes.

I frequently spin the camera quickly with my middle mouse button, then want to align it to east or west or whatever. It's a lot easier to "spin the camera left and then align it" than it is to process in your head what your previous direction was, then left or right of that, then right click the compass and select the correct option.

I hope you'll accept the change!